### PR TITLE
Refactor GTFS functions to avoid global variables

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from caltrain_mcp import gtfs
 
 @pytest.fixture(autouse=True)
 def fake_gtfs(monkeypatch):
-    """Inject minimal GTFS frames so load_gtfs_data() isn't needed."""
+    """Provide a minimal :class:`~caltrain_mcp.gtfs.GTFSData` object for tests."""
     # --- stops -------------------------------------------------
     stops_csv = """stop_id,stop_name,location_type,parent_station
 100,San Francisco Caltrain,1,
@@ -16,33 +16,31 @@ def fake_gtfs(monkeypatch):
 200,Palo Alto,1,
 201,Palo Alto Platform 1,0,200
 """
-    gtfs.ALL_STOPS_DF = pd.read_csv(StringIO(stops_csv))
-    # Ensure consistent data types for stop_id columns (like in real GTFS loading)
-    gtfs.ALL_STOPS_DF["stop_id"] = gtfs.ALL_STOPS_DF["stop_id"].astype(str)
+    all_stops_df = pd.read_csv(StringIO(stops_csv))
+    all_stops_df["stop_id"] = all_stops_df["stop_id"].astype(str)
 
-    gtfs.STATIONS_DF = gtfs.ALL_STOPS_DF[gtfs.ALL_STOPS_DF.location_type == 1].copy()
-    gtfs.STATIONS_DF["normalized_name"] = (
-        gtfs.STATIONS_DF.stop_name.str.lower().str.replace(" caltrain", "")
+    stations_df = all_stops_df[all_stops_df.location_type == 1].copy()
+    stations_df["normalized_name"] = (
+        stations_df.stop_name.str.lower().str.replace(" caltrain", "")
     )
 
     # --- calendar ---------------------------------------------
     cal_csv = """service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date
 WEEKDAY,1,1,1,1,1,0,0,20250101,20251231
 """
-    gtfs.CALENDAR_DF = pd.read_csv(StringIO(cal_csv))
+    calendar_df = pd.read_csv(StringIO(cal_csv))
 
     # --- trips -------------------------------------------------
     trips_csv = "route_id,service_id,trip_id,trip_headsign,trip_short_name\n1,WEEKDAY,T1,San Jose,SJ\n"
-    gtfs.TRIPS_DF = pd.read_csv(StringIO(trips_csv))
+    trips_df = pd.read_csv(StringIO(trips_csv))
 
     # --- stop_times -------------------------------------------
     st_csv = """trip_id,arrival_time,departure_time,stop_id,stop_sequence
 T1,08:00:00,08:00:00,101,1
 T1,08:50:00,08:50:00,201,2
 """
-    gtfs.STOP_TIMES_DF = pd.read_csv(StringIO(st_csv))
-    # Ensure consistent data types for stop_id columns (like in real GTFS loading)
-    gtfs.STOP_TIMES_DF["stop_id"] = gtfs.STOP_TIMES_DF["stop_id"].astype(str)
+    stop_times_df = pd.read_csv(StringIO(st_csv))
+    stop_times_df["stop_id"] = stop_times_df["stop_id"].astype(str)
 
     def _conv(v):
         if pd.isna(v):
@@ -51,11 +49,23 @@ T1,08:50:00,08:50:00,201,2
             return str(int(v))
         return str(v)
 
-    parent_station_str = gtfs.ALL_STOPS_DF["parent_station"].apply(_conv)
-    gtfs.ALL_STOPS_DF["parent_station_str"] = parent_station_str
+    parent_station_str = all_stops_df["parent_station"].apply(_conv)
+    all_stops_df["parent_station_str"] = parent_station_str
     grouped = (
-        gtfs.ALL_STOPS_DF.dropna(subset=["parent_station_str"])
+        all_stops_df.dropna(subset=["parent_station_str"])
         .groupby("parent_station_str")["stop_id"]
         .apply(lambda s: s.astype(str).tolist())
     )
-    gtfs.STATION_TO_PLATFORM_STOPS = grouped.to_dict()
+    station_to_platform = grouped.to_dict()
+
+    data = gtfs.GTFSData(
+        all_stops=all_stops_df,
+        stations=stations_df,
+        trips=trips_df,
+        stop_times=stop_times_df,
+        calendar=calendar_df,
+        station_to_platform_stops=station_to_platform,
+    )
+
+    monkeypatch.setattr(gtfs, "get_default_data", lambda: data)
+    return data

--- a/tests/test_gtfs.py
+++ b/tests/test_gtfs.py
@@ -5,18 +5,18 @@ import pytest
 from caltrain_mcp import gtfs
 
 
-def test_find_station_abbreviation():
-    assert gtfs.find_station("sf") == "100"  # abbreviation map
-    assert gtfs.find_station("Palo Alto") == "200"  # regular match
+def test_find_station_abbreviation(fake_gtfs):
+    assert gtfs.find_station("sf", fake_gtfs) == "100"  # abbreviation map
+    assert gtfs.find_station("Palo Alto", fake_gtfs) == "200"  # regular match
 
 
-def test_find_station_error_cases():
+def test_find_station_error_cases(fake_gtfs):
     """Test error handling in find_station function"""
     with pytest.raises(ValueError, match="Station not found: nonexistent"):
-        gtfs.find_station("nonexistent")
+        gtfs.find_station("nonexistent", fake_gtfs)
 
     with pytest.raises(ValueError, match="Station not found: xyz123"):
-        gtfs.find_station("xyz123")
+        gtfs.find_station("xyz123", fake_gtfs)
 
 
 def test_time_helpers():
@@ -42,43 +42,43 @@ def test_time_helpers_edge_cases():
     assert gtfs.seconds_to_time(86399) == "23:59:59"
 
 
-def test_get_station_name():
+def test_get_station_name(fake_gtfs):
     """Test station name lookup"""
-    assert gtfs.get_station_name("100") == "San Francisco Caltrain"
-    assert gtfs.get_station_name("200") == "Palo Alto"
+    assert gtfs.get_station_name("100", fake_gtfs) == "San Francisco Caltrain"
+    assert gtfs.get_station_name("200", fake_gtfs) == "Palo Alto"
     # Test nonexistent station - should return the ID itself
-    assert gtfs.get_station_name("999") == "999"
+    assert gtfs.get_station_name("999", fake_gtfs) == "999"
 
 
-def test_get_platform_stops_for_station():
+def test_get_platform_stops_for_station(fake_gtfs):
     """Test platform stop lookup"""
-    assert gtfs.get_platform_stops_for_station("100") == ["101"]
-    assert gtfs.get_platform_stops_for_station("200") == ["201"]
+    assert gtfs.get_platform_stops_for_station("100", fake_gtfs) == ["101"]
+    assert gtfs.get_platform_stops_for_station("200", fake_gtfs) == ["201"]
     # Test nonexistent station
-    assert gtfs.get_platform_stops_for_station("999") == []
+    assert gtfs.get_platform_stops_for_station("999", fake_gtfs) == []
 
 
-def test_get_active_service_ids():
+def test_get_active_service_ids(fake_gtfs):
     """Test service ID lookup for different dates"""
     # Wednesday (should have WEEKDAY service)
-    service_ids = gtfs.get_active_service_ids(date(2025, 1, 1))
+    service_ids = gtfs.get_active_service_ids(date(2025, 1, 1), fake_gtfs)
     assert service_ids == ["WEEKDAY"]
 
     # Saturday (should have no service based on our test data)
-    service_ids = gtfs.get_active_service_ids(date(2025, 1, 4))
+    service_ids = gtfs.get_active_service_ids(date(2025, 1, 4), fake_gtfs)
     assert service_ids == []
 
 
-def test_find_next_trains_edge_cases():
+def test_find_next_trains_edge_cases(fake_gtfs):
     """Test edge cases in find_next_trains function"""
     # No active service IDs (weekend)
-    trains = gtfs.find_next_trains("100", "200", 0, date(2025, 1, 4))
+    trains = gtfs.find_next_trains("100", "200", 0, date(2025, 1, 4), fake_gtfs)
     assert trains == []
 
     # Valid date but after all departures
-    trains = gtfs.find_next_trains("100", "200", 32400, date(2025, 1, 1))  # 9 AM
+    trains = gtfs.find_next_trains("100", "200", 32400, date(2025, 1, 1), fake_gtfs)  # 9 AM
     assert trains == []
 
     # Nonexistent stations (should return empty due to no platforms)
-    trains = gtfs.find_next_trains("999", "200", 0, date(2025, 1, 1))
+    trains = gtfs.find_next_trains("999", "200", 0, date(2025, 1, 1), fake_gtfs)
     assert trains == []


### PR DESCRIPTION
## Summary
- encapsulate GTFS tables in a `GTFSData` dataclass
- load data lazily via `get_default_data()` instead of globals
- update server to use new API
- adjust tests for `GTFSData`

## Testing
- `pip install pandas pytest pytest-asyncio`
- `pip install mcp`
- `PYTHONPATH=$PWD/src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e38165e38832a87563a68557d09b6