### PR TITLE
fix: apply GTFS calendar date exceptions

### DIFF
--- a/src/caltrain_mcp/gtfs.py
+++ b/src/caltrain_mcp/gtfs.py
@@ -20,6 +20,7 @@ class GTFSData:
     trips: pd.DataFrame
     stop_times: pd.DataFrame
     calendar: pd.DataFrame
+    calendar_dates: pd.DataFrame
     station_to_platform_stops: dict[str, list[str]]
 
 
@@ -49,6 +50,13 @@ def load_gtfs_data() -> GTFSData:
     trips_df = pd.read_csv(gtfs_folder / "trips.txt")
     stop_times_df = pd.read_csv(gtfs_folder / "stop_times.txt")
     calendar_df = pd.read_csv(gtfs_folder / "calendar.txt")
+    calendar_dates_path = gtfs_folder / "calendar_dates.txt"
+    if calendar_dates_path.exists():
+        calendar_dates_df = pd.read_csv(calendar_dates_path)
+    else:
+        calendar_dates_df = pd.DataFrame(
+            columns=["service_id", "date", "exception_type"]
+        )
 
     # Ensure consistent data types for stop_id columns
     all_stops_df["stop_id"] = all_stops_df["stop_id"].astype(str)
@@ -89,6 +97,7 @@ def load_gtfs_data() -> GTFSData:
         trips=trips_df,
         stop_times=stop_times_df,
         calendar=calendar_df,
+        calendar_dates=calendar_dates_df,
         station_to_platform_stops=station_to_platform,
     )
 
@@ -123,7 +132,21 @@ def get_active_service_ids(target_date: date, data: GTFSData) -> list[str]:
         & (calendar_df["end_date"] >= int(date_str))
     ]
 
-    return active_services["service_id"].tolist()
+    active_service_ids = dict.fromkeys(active_services["service_id"].astype(str))
+
+    # Apply date-specific GTFS exceptions after the regular weekly schedule.
+    # exception_type 1 adds service and exception_type 2 removes service.
+    exceptions = data.calendar_dates[
+        data.calendar_dates["date"].astype(str) == date_str
+    ]
+    for exception in exceptions.itertuples(index=False):
+        service_id = str(exception.service_id)
+        if exception.exception_type == 1:
+            active_service_ids[service_id] = None
+        elif exception.exception_type == 2:
+            active_service_ids.pop(service_id, None)
+
+    return list(active_service_ids)
 
 
 def find_station(name: str, data: GTFSData) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,14 @@ WEEKDAY,1,1,1,1,1,0,0,20250101,20251231
 """
     calendar_df = pd.read_csv(StringIO(cal_csv))
 
+    # --- calendar_dates ---------------------------------------
+    cal_dates_csv = """service_id,date,exception_type
+WEEKDAY,20250102,2
+SPECIAL,20250102,1
+SATURDAY,20250104,1
+"""
+    calendar_dates_df = pd.read_csv(StringIO(cal_dates_csv))
+
     # --- trips -------------------------------------------------
     trips_csv = "route_id,service_id,trip_id,trip_headsign,trip_short_name\n1,WEEKDAY,T1,San Jose,SJ\n"
     trips_df = pd.read_csv(StringIO(trips_csv))
@@ -64,6 +72,7 @@ T1,08:50:00,08:50:00,201,2
         trips=trips_df,
         stop_times=stop_times_df,
         calendar=calendar_df,
+        calendar_dates=calendar_dates_df,
         station_to_platform_stops=station_to_platform,
     )
 

--- a/tests/test_gtfs.py
+++ b/tests/test_gtfs.py
@@ -60,19 +60,27 @@ def test_get_platform_stops_for_station(fake_gtfs):
 
 def test_get_active_service_ids(fake_gtfs):
     """Test service ID lookup for different dates"""
-    # Wednesday (should have WEEKDAY service)
+    # Normal Wednesday follows the weekly calendar.
     service_ids = gtfs.get_active_service_ids(date(2025, 1, 1), fake_gtfs)
     assert service_ids == ["WEEKDAY"]
 
-    # Saturday (should have no service based on our test data)
+    # A date-specific addition can activate a service absent from calendar.txt.
     service_ids = gtfs.get_active_service_ids(date(2025, 1, 4), fake_gtfs)
+    assert service_ids == ["SATURDAY"]
+
+    # Date-specific exceptions can replace regular weekday service.
+    service_ids = gtfs.get_active_service_ids(date(2025, 1, 2), fake_gtfs)
+    assert service_ids == ["SPECIAL"]
+
+    # A date without regular service or an exception remains inactive.
+    service_ids = gtfs.get_active_service_ids(date(2025, 1, 5), fake_gtfs)
     assert service_ids == []
 
 
 def test_find_next_trains_edge_cases(fake_gtfs):
     """Test edge cases in find_next_trains function"""
     # No active service IDs (weekend)
-    trains = gtfs.find_next_trains("100", "200", 0, date(2025, 1, 4), fake_gtfs)
+    trains = gtfs.find_next_trains("100", "200", 0, date(2025, 1, 5), fake_gtfs)
     assert trains == []
 
     # Valid date but after all departures

--- a/tests/test_station_matching.py
+++ b/tests/test_station_matching.py
@@ -38,6 +38,7 @@ def _make_data():
         "start_date",
         "end_date",
     ])
+    calendar_dates = pd.DataFrame(columns=["service_id", "date", "exception_type"])
 
     return gtfs.GTFSData(
         all_stops=all_stops,
@@ -45,6 +46,7 @@ def _make_data():
         trips=trips,
         stop_times=stop_times,
         calendar=calendar,
+        calendar_dates=calendar_dates,
         station_to_platform_stops={},
     )
 
@@ -69,4 +71,3 @@ def test_prefix_south_san_resolves_south_sf():
 def test_abbreviation_ssf_points_to_south_sf():
     data = _make_data()
     assert gtfs.find_station("ssf", data) == "110"
-


### PR DESCRIPTION
## Summary

- load the optional `calendar_dates.txt` table alongside `calendar.txt`
- apply GTFS exception type 1 additions and type 2 removals after the weekly schedule
- cover add-only, replacement-service, unaffected, and no-service dates

## Root cause and impact

`get_active_service_ids()` previously considered only the recurring weekly schedule in `calendar.txt`. Date-specific additions and removals were ignored, so holiday replacement service and special-event trips could never be selected correctly.

## Validation

- `uv run pytest -q` — 23 passed
- `uv run ruff check .`
- `uv run mypy src`
- bundled-feed checks confirm Presidents’ Day selects special service and Memorial Day selects weekend service